### PR TITLE
Batch jobs WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .stack-work
 cabal.sandbox.config
 dist-stack
+stack.yaml.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* 0.3.0 Remeike Forbes 2022-11-23
+
+  Introduce batched jobs
+
 * 0.2.0 Remeike Forbes
 
   Coerce jobs to string (to work with Redis 5)

--- a/hworker.cabal
+++ b/hworker.cabal
@@ -1,5 +1,5 @@
 name:                hworker
-version:             0.2.0
+version:             0.3.0
 synopsis:            A reliable at-least-once job queue built on top of redis.
 description:         See README.
 homepage:            http://github.com/positiondev/hworker

--- a/hworker.cabal
+++ b/hworker.cabal
@@ -22,6 +22,7 @@ library
                      , time >= 1.5
                      , attoparsec
                      , uuid >= 1.2.6
+                     , mtl
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -43,3 +44,4 @@ Test-Suite hworker-test
                      , hspec >= 2
                      , hspec-contrib
                      , HUnit
+                     , mtl

--- a/src/System/Hworker.hs
+++ b/src/System/Hworker.hs
@@ -451,8 +451,6 @@ worker hw =
                                             \return nil"
                                             [progressQueue hw, failedQueue hw]
                                             [t, B8.pack (show (hworkerFailedQueueSize hw - 1))])
-                           void $ R.runRedis (hworkerConnection hw)
-                                             (R.hdel (progressQueue hw) [t])
                            delayAndRun
 
                          Just batch -> do

--- a/src/System/Hworker.hs
+++ b/src/System/Hworker.hs
@@ -59,7 +59,7 @@ module System.Hworker
        , create
        , createWith
        , destroy
-       , batchJob
+       , batchSummary
        , worker
        , monitor
          -- * Queuing Jobs
@@ -607,8 +607,8 @@ initBatch hw = do
       ]
   return batch
 
-batchJob :: Hworker s t -> BatchID -> IO (Maybe BatchSummary)
-batchJob hw batch = do
+batchSummary :: Hworker s t -> BatchID -> IO (Maybe BatchSummary)
+batchSummary hw batch = do
   r <- R.runRedis (hworkerConnection hw) (R.hgetall (batchCounter hw batch))
   case r of
     Left err -> hwlog hw err >> return Nothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - '.'
 - 'example'
 extra-deps: []
-resolver: lts-3.1
+resolver: lts-18.18

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -241,7 +241,7 @@ main = hspec $
                assertEqual "Should only have stored 2"
                            [AlwaysFailJob,AlwaysFailJob] jobs
 
-     fdescribe "Batch" $
+     describe "Batch" $
        do it "should set up a batch job" $
             do mvar <- newMVar 0
                hworker <- createWith (conf "simpleworker-1" (SimpleState mvar))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -246,23 +246,21 @@ main = hspec $
             do mvar <- newMVar 0
                hworker <- createWith (conf "simpleworker-1" (SimpleState mvar))
                Just batch <- initBatch hworker >>= batchJob hworker
-               batchTotal batch `shouldBe` 0
-               batchCompleted batch `shouldBe` 0
-               batchSuccesses batch `shouldBe` 0
-               batchFailures batch `shouldBe` 0
-               batchRetries batch `shouldBe` 0
-               batchStatus batch `shouldBe` BatchQueuing
+               batchSummaryTotal batch `shouldBe` 0
+               batchSummaryCompleted batch `shouldBe` 0
+               batchSummarySuccesses batch `shouldBe` 0
+               batchSummaryFailures batch `shouldBe` 0
+               batchSummaryRetries batch `shouldBe` 0
+               batchSummaryStatus batch `shouldBe` BatchQueuing
                destroy hworker
-
           it "should increment batch total after queueing a batch job" $
             do mvar <- newMVar 0
                hworker <- createWith (conf "simpleworker-1" (SimpleState mvar))
                ref <- initBatch hworker
                queueBatched hworker SimpleJob ref False
                Just batch <- batchJob hworker ref
-               batchTotal batch `shouldBe` 1
+               batchSummaryTotal batch `shouldBe` 1
                destroy hworker
-
           it "should increment success and completed after completing a successful batch job" $
             do mvar <- newMVar 0
                hworker <- createWith (conf "simpleworker-1" (SimpleState mvar))
@@ -271,14 +269,13 @@ main = hspec $
                queueBatched hworker SimpleJob ref False
                threadDelay 30000
                Just batch <- batchJob hworker ref
-               batchTotal batch `shouldBe` 1
-               batchFailures batch `shouldBe` 0
-               batchSuccesses batch `shouldBe` 1
-               batchCompleted batch `shouldBe` 1
-               batchStatus batch `shouldBe` BatchQueuing
+               batchSummaryTotal batch `shouldBe` 1
+               batchSummaryFailures batch `shouldBe` 0
+               batchSummarySuccesses batch `shouldBe` 1
+               batchSummaryCompleted batch `shouldBe` 1
+               batchSummaryStatus batch `shouldBe` BatchQueuing
                killThread wthread
                destroy hworker
-
           it "should increment failure and completed after completing a failed batch job" $
             do mvar <- newMVar 0
                hworker <- createWith (conf "failworker-1" (FailState mvar))
@@ -287,24 +284,22 @@ main = hspec $
                queueBatched hworker FailJob ref False
                threadDelay 30000
                Just batch <- batchJob hworker ref
-               batchTotal batch `shouldBe` 1
-               batchFailures batch `shouldBe` 1
-               batchSuccesses batch `shouldBe` 0
-               batchCompleted batch `shouldBe` 1
-               batchStatus batch `shouldBe` BatchQueuing
+               batchSummaryTotal batch `shouldBe` 1
+               batchSummaryFailures batch `shouldBe` 1
+               batchSummarySuccesses batch `shouldBe` 0
+               batchSummaryCompleted batch `shouldBe` 1
+               batchSummaryStatus batch `shouldBe` BatchQueuing
                killThread wthread
                destroy hworker
-
           it "should change job status to processing when indicated in queued job" $
             do mvar <- newMVar 0
                hworker <- createWith (conf "simpleworker-1" (SimpleState mvar))
                ref <- initBatch hworker
                queueBatched hworker SimpleJob ref True
                Just batch <- batchJob hworker ref
-               batchTotal batch `shouldBe` 1
-               batchStatus batch `shouldBe` BatchProcessing
+               batchSummaryTotal batch `shouldBe` 1
+               batchSummaryStatus batch `shouldBe` BatchProcessing
                destroy hworker
-
           it "should change job status finished when last process" $
             do mvar <- newMVar 0
                hworker <- createWith (conf "simpleworker-1" (SimpleState mvar))
@@ -313,8 +308,8 @@ main = hspec $
                queueBatched hworker SimpleJob ref True
                threadDelay 30000
                Just batch <- batchJob hworker ref
-               batchTotal batch `shouldBe` 1
-               batchStatus batch `shouldBe` BatchFinished
+               batchSummaryTotal batch `shouldBe` 1
+               batchSummaryStatus batch `shouldBe` BatchFinished
                killThread wthread
                destroy hworker
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -193,6 +193,7 @@ main = hspec $
                wthread <- forkIO (worker hworker)
                queue hworker RetryJob
                threadDelay 50000
+               killThread wthread
                destroy hworker
                v <- takeMVar mvar
                assertEqual "State should be 2, since it got retried" 2 v
@@ -205,6 +206,7 @@ main = hspec $
                wthread <- forkIO (worker hworker)
                queue hworker FailJob
                threadDelay 30000
+               killThread wthread
                destroy hworker
                v <- takeMVar mvar
                assertEqual "State should be 1, since failing run wasn't retried" 1 v
@@ -215,6 +217,7 @@ main = hspec $
                wthread <- forkIO (worker hworker)
                queue hworker FailJob
                threadDelay 30000
+               killThread wthread
                jobs <- failed hworker
                destroy hworker
                assertEqual "Should have failed job" [FailJob] jobs
@@ -230,6 +233,7 @@ main = hspec $
                queue hworker AlwaysFailJob
                queue hworker AlwaysFailJob
                threadDelay 100000
+               killThread wthread
                jobs <- failed hworker
                destroy hworker
                v <- takeMVar mvar


### PR DESCRIPTION
So here's a rough first pass at adding batched jobs. I tried to go with what I think is a straightforward approach. Basically you start by initializing a batched job, which returns a `BatchID` and creates a hash with a bunch of counters used for tracking the state of that job. You can use that `BatchID` to queue new jobs as part of that batch or to check in on the state of the batch. When queueing you can indicate whether the job being queued is the last one. As jobs are being processed the counters are updated accordingly. Once the last job is processed the status of the job is set to finished and callback is applied to the latest `BatchJob` record, which can be used by the application for persisting that information or just telling it that everything is done.

There's a few open questions I have and some additional things I want to note:

1. Right now `BatchID` simply wraps a `UUID`. I wonder if this should be a `ByteString` instead? It would still be a UUID, just serialized as a ByteString. I was thinking about this because this type is part of the public API, so might make things a little easier if user don't have to the `uuid` library as a direct dependency? Or maybe it doesn't matter?
2. I wonder if the `batchCompleted` counter is necessary since it should technically should just be `batchSuccessess + batchFailures`?
3. Not sure how much I should care about this sort of thing, but I did create a separate `queueBatched` function, so that I wouldn't have to mess with the `queue` function and cause a breaking change.
4. Right now `queueBatched` takes a `Bool` argument that indicates whether the job being queued is the last one, but I'm wondering if I should just create a separate function for this altogether, like `stopQueueing` or whatever.
5. Also, maybe I should prevent queueing new jobs if the status is no longer `BatchQueuing`?
6. I also realize that all the incrementing functions used inside `worker` are currently not atomic, so I'll either have to incorporate them into the existing lua scripts or change everything over to using `multiexec`, assuming the later works. I personally think it would be awesome to be able to drop the lua scripts, since it'd make debugging things a bit easier.
7. One other thing I haven't done yet is having the option to make the queueing process itself atomic, so that either everything thing gets queued or nothing does. I'm thinking I'll do this with a separate PR.