### PR TITLE
Make queuing batched jobs atomic

### DIFF
--- a/hworker.cabal
+++ b/hworker.cabal
@@ -32,6 +32,8 @@ Test-Suite hworker-test
   hs-source-dirs:      src test
   main-is:             Spec.hs
   other-modules:       System.Hworker
+  ghc-options:         -Wall
+                       -fno-warn-unused-do-bind
   build-depends:       base >= 4.7 && < 5
                      , aeson
                      , hedis >= 0.6.5

--- a/hworker.cabal
+++ b/hworker.cabal
@@ -22,6 +22,7 @@ library
                      , attoparsec
                      , uuid >= 1.2.6
                      , mtl
+                     , conduit
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -43,3 +44,4 @@ Test-Suite hworker-test
                      , hspec-contrib
                      , HUnit
                      , mtl
+                     , conduit

--- a/src/System/Hworker.hs
+++ b/src/System/Hworker.hs
@@ -95,7 +95,7 @@ import qualified Data.Aeson             as A
 import           Data.ByteString         ( ByteString )
 import qualified Data.ByteString.Char8  as B8
 import qualified Data.ByteString.Lazy   as LB
-import           Data.Conduit            ( ConduitT, (.|) )
+import           Data.Conduit            ( ConduitT )
 import qualified Data.Conduit           as Conduit
 import           Data.Either             ( isRight )
 import           Data.Maybe              ( isJust, mapMaybe, listToMaybe )
@@ -430,7 +430,7 @@ queue hw j = do
 -- in the list will queue.
 
 queueBatch :: Job s t => Hworker s t -> BatchId -> Bool -> [t] -> IO Bool
-queueBatch hw batch close js  =
+queueBatch hw batch close js =
   withBatchQueue hw batch $ runRedis (hworkerConnection hw) $
     R.multiExec $ do
       mapM_
@@ -485,7 +485,7 @@ streamBatch hw batch close producer =
   in
   withBatchQueue hw batch
     $ runRedis (hworkerConnection hw)
-    $ R.multiExec (Conduit.runConduit (producer .| sink))
+    $ R.multiExec (Conduit.connect producer sink)
 
 
 withBatchQueue ::

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,23 +12,11 @@ import           Control.Concurrent.MVar  ( MVar, modifyMVarMasked_, newMVar
 import           Control.Monad            ( replicateM_, void )
 import           Control.Monad.Trans      ( lift, liftIO )
 import           Data.Aeson               ( FromJSON(..), ToJSON(..) )
-import           Data.ByteString          ( ByteString )
-import           Data.Conduit             ( ConduitT, (.|) )
 import qualified Data.Conduit            as Conduit
 import           Data.Text                ( Text )
 import qualified Data.Text               as T
-import           Database.Redis           ( Redis
-                                          , RedisTx
-                                          , TxResult(..)
-                                          , Connection
-                                          , ConnectInfo
-                                          , Queued
-                                          , Reply
-                                          , runRedis
-                                          )
 import qualified Database.Redis          as Redis
 import           GHC.Generics             ( Generic)
-import           System.IO                ( stdout, hFlush )
 import           Test.Hspec
 import           Test.HUnit               ( assertEqual )
 --------------------------------------------------------------------------------
@@ -150,9 +138,9 @@ main = hspec $ do
       queue hworker FailJob
       threadDelay 30000
       killThread wthread
-      jobs <- failed hworker
+      failedJobs <- failed hworker
       destroy hworker
-      assertEqual "Should have failed job" [FailJob] jobs
+      assertEqual "Should have failed job" [FailJob] failedJobs
 
     it "should only store failedQueueSize failed jobs" $ do
       mvar <- newMVar 0
@@ -167,11 +155,11 @@ main = hspec $ do
       queue hworker AlwaysFailJob
       threadDelay 100000
       killThread wthread
-      jobs <- failed hworker
+      failedJobs <- failed hworker
       destroy hworker
       v <- takeMVar mvar
       assertEqual "State should be 4, since all jobs were run" 4 v
-      assertEqual "Should only have stored 2" [AlwaysFailJob,AlwaysFailJob] jobs
+      assertEqual "Should only have stored 2" [AlwaysFailJob,AlwaysFailJob] failedJobs
 
   describe "Batch" $ do
     it "should set up a batch job" $ do
@@ -270,9 +258,9 @@ main = hspec $ do
       queueBatch hworker batch False [SimpleJob]
       threadDelay 30000
       stopBatchQueueing hworker batch
-      Just batch <- batchSummary hworker batch
-      batchSummaryQueued batch `shouldBe` 1
-      batchSummaryStatus batch `shouldBe` BatchFinished
+      Just batch' <- batchSummary hworker batch
+      batchSummaryQueued batch' `shouldBe` 1
+      batchSummaryStatus batch' `shouldBe` BatchFinished
       killThread wthread
       destroy hworker
 
@@ -352,7 +340,7 @@ main = hspec $ do
         mvar <- newMVar 0
         hworker <- createWith (conf "simpleworker-1" (SimpleState mvar))
         batch <- startBatch hworker Nothing
-        _ <- runRedis (hworkerConnection hworker) $ Redis.watch [batchCounter hworker batch]
+        _ <- Redis.runRedis (hworkerConnection hworker) $ Redis.watch [batchCounter hworker batch]
         streamBatch hworker batch True $ replicateM_ 20 $ Conduit.yield SimpleJob
         ls <- jobs hworker
         destroy hworker
@@ -487,12 +475,12 @@ main = hspec $ do
       wthread <- forkIO (worker hworker1)
       queue hworker2 SimpleJob
       threadDelay 100000
-      jobs <- broken hworker2
+      brokenJobs <- broken hworker2
       killThread wthread
       destroy hworker1
       v <- takeMVar mvar
       assertEqual "State should be 0, as nothing should have happened" 0 v
-      assertEqual "Should be one broken job, as serialization is wrong" 1 (length jobs)
+      assertEqual "Should be one broken job, as serialization is wrong" 1 (length brokenJobs)
 
   describe "Dump jobs" $ do
     it "should return the job that was queued" $ do
@@ -539,7 +527,7 @@ instance ToJSON SimpleJob
 instance FromJSON SimpleJob
 
 newtype SimpleState =
-  SimpleState { unSimpleState :: MVar Int }
+  SimpleState (MVar Int)
 
 instance Job SimpleState SimpleJob where
   job (SimpleState mvar) SimpleJob =
@@ -553,7 +541,7 @@ instance ToJSON ExJob
 instance FromJSON ExJob
 
 newtype ExState =
-  ExState { unExState :: MVar Int }
+  ExState (MVar Int)
 
 instance Job ExState ExJob where
   job (ExState mvar) ExJob = do
@@ -571,7 +559,7 @@ instance ToJSON RetryJob
 instance FromJSON RetryJob
 
 newtype RetryState =
-  RetryState { unRetryState :: MVar Int }
+  RetryState (MVar Int)
 
 instance Job RetryState RetryJob where
   job (RetryState mvar) RetryJob = do
@@ -589,7 +577,7 @@ instance ToJSON FailJob
 instance FromJSON FailJob
 
 newtype FailState =
-  FailState { unFailState :: MVar Int }
+  FailState (MVar Int)
 
 instance Job FailState FailJob where
   job (FailState mvar) FailJob = do
@@ -607,7 +595,7 @@ instance ToJSON AlwaysFailJob
 instance FromJSON AlwaysFailJob
 
 newtype AlwaysFailState =
-  AlwaysFailState { unAlwaysFailState :: MVar Int }
+  AlwaysFailState (MVar Int)
 
 instance Job AlwaysFailState AlwaysFailJob where
   job (AlwaysFailState mvar) AlwaysFailJob = do
@@ -622,7 +610,7 @@ instance ToJSON TimedJob
 instance FromJSON TimedJob
 
 newtype TimedState =
-  TimedState { unTimedState :: MVar Int }
+  TimedState (MVar Int)
 
 instance Job TimedState TimedJob where
   job (TimedState mvar) (TimedJob delay) = do
@@ -638,7 +626,7 @@ instance ToJSON BigJob
 instance FromJSON BigJob
 
 newtype BigState =
-  BigState { unBigState :: MVar Int }
+  BigState (MVar Int)
 
 instance Job BigState BigJob where
   job (BigState mvar) (BigJob _) =


### PR DESCRIPTION
So a couple of things here.
1. I've replaced `queueBatched` with `queueBatch` which instead of queueing a single job to a batch, actually queues a list of jobs together and does so atomically. I figured that if you're working with batched jobs it's more likely that you'd want to queue them as a group anyway. And obviously you could still queue a single job by placing it in a list anyway.
2. I've also added the option to queue a group of jobs by streaming them in. 